### PR TITLE
Allow repeated '--program-args'

### DIFF
--- a/cmd/cli/flink/api.go
+++ b/cmd/cli/flink/api.go
@@ -7,6 +7,6 @@ type FlinkRestAPI interface {
 	CreateSavepoint(jobID string, savepointPath string) (CreateSavepointResponse, error)
 	MonitorSavepointCreation(jobID string, requestID string) (MonitorSavepointCreationResponse, error)
 	RetrieveJobs() ([]Job, error)
-	RunJar(jarID string, entryClass string, jarArgs string, parallelism int, savepointPath string, allowNonRestoredState bool) error
+	RunJar(jarID string, entryClass string, jarArgs []string, parallelism int, savepointPath string, allowNonRestoredState bool) error
 	UploadJar(filename string) (UploadJarResponse, error)
 }

--- a/cmd/cli/flink/run_jar.go
+++ b/cmd/cli/flink/run_jar.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"strings"
 )
 
 type runJarRequest struct {
@@ -16,10 +17,10 @@ type runJarRequest struct {
 }
 
 // RunJar executes a specific JAR file with the supplied parameters on the Flink cluster
-func (c FlinkRestClient) RunJar(jarID string, entryClass string, jarArgs string, parallelism int, savepointPath string, allowNonRestoredState bool) error {
+func (c FlinkRestClient) RunJar(jarID string, entryClass string, jarArgs []string, parallelism int, savepointPath string, allowNonRestoredState bool) error {
 	runJarRequest := runJarRequest{
 		EntryClass:            entryClass,
-		ProgramArgs:           jarArgs,
+		ProgramArgs:           strings.Join(jarArgs, " "),
 		Parallelism:           parallelism,
 		AllowNonRestoredState: allowNonRestoredState,
 		SavepointPath:         savepointPath,

--- a/cmd/cli/flink/run_jar_test.go
+++ b/cmd/cli/flink/run_jar_test.go
@@ -16,7 +16,7 @@ func TestRunJarReturnsAnErrorWhenTheStatusIsNot200(t *testing.T) {
 		BaseURL: server.URL,
 		Client:  retryablehttp.NewClient(),
 	}
-	err := api.RunJar("id", "MainClass", "", 1, "/data/flink", false)
+	err := api.RunJar("id", "MainClass", []string{}, 1, "/data/flink", false)
 
 	assert.EqualError(t, err, "Unexpected response status 202 with body {}")
 }
@@ -29,7 +29,7 @@ func TestRunJarCorrectlyReturnsNilWhenTheCallSucceeds(t *testing.T) {
 		BaseURL: server.URL,
 		Client:  retryablehttp.NewClient(),
 	}
-	err := api.RunJar("id", "MainClass", "", 1, "/data/flink", false)
+	err := api.RunJar("id", "MainClass", []string{}, 1, "/data/flink", false)
 
 	assert.Nil(t, err)
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -72,7 +72,7 @@ func DeployAction(c *cli.Context) error {
 		deploy.Parallelism = 1
 	}
 
-	programArgs := c.String("program-args")
+	programArgs := c.StringSlice("program-args")
 	if len(programArgs) > 0 {
 		deploy.ProgramArgs = programArgs
 	}
@@ -143,7 +143,7 @@ func UpdateAction(c *cli.Context) error {
 		update.Parallelism = 1
 	}
 
-	programArgs := c.String("program-args")
+	programArgs := c.StringSlice("program-args")
 	if len(programArgs) > 0 {
 		update.ProgramArgs = programArgs
 	}
@@ -269,9 +269,9 @@ func main() {
 					Name:  "parallelism, p",
 					Usage: "The parallelism count",
 				},
-				cli.StringFlag{
+				cli.StringSliceFlag{
 					Name:  "program-args, pa",
-					Usage: "The arguments to pass to the program execution",
+					Usage: "The arguments to pass to the program execution. This flag may be repeated to provide multiple arguments",
 				},
 				cli.StringFlag{
 					Name:  "savepoint-dir, sd",
@@ -317,7 +317,7 @@ func main() {
 					Name:  "parallelism, p",
 					Usage: "The parallelism count",
 				},
-				cli.StringFlag{
+				cli.StringSliceFlag{
 					Name:  "program-args, pa",
 					Usage: "The arguments to pass to the program execution",
 				},

--- a/cmd/cli/operations/deploy.go
+++ b/cmd/cli/operations/deploy.go
@@ -15,7 +15,7 @@ type Deploy struct {
 	LocalFilename         string
 	EntryClass            string
 	Parallelism           int
-	ProgramArgs           string
+	ProgramArgs           []string
 	SavepointDir          string
 	SavepointPath         string
 	AllowNonRestoredState bool

--- a/cmd/cli/operations/flink_api_test.go
+++ b/cmd/cli/operations/flink_api_test.go
@@ -38,7 +38,7 @@ func (c TestFlinkRestClient) MonitorSavepointCreation(jobID string, requestID st
 func (c TestFlinkRestClient) RetrieveJobs() ([]flink.Job, error) {
 	return mockedRetrieveJobsResponse, mockedRetrieveJobsError
 }
-func (c TestFlinkRestClient) RunJar(jarID string, entryClass string, jarArgs string, parallelism int, savepointPath string, allowNonRestoredState bool) error {
+func (c TestFlinkRestClient) RunJar(jarID string, entryClass string, jarArgs []string, parallelism int, savepointPath string, allowNonRestoredState bool) error {
 	return mockedRunJarError
 }
 func (c TestFlinkRestClient) UploadJar(filename string) (flink.UploadJarResponse, error) {

--- a/cmd/cli/operations/update_job.go
+++ b/cmd/cli/operations/update_job.go
@@ -20,7 +20,7 @@ type UpdateJob struct {
 	APIToken              string
 	EntryClass            string
 	Parallelism           int
-	ProgramArgs           string
+	ProgramArgs           []string
 	SavepointDir          string
 	AllowNonRestoredState bool
 }


### PR DESCRIPTION
The Flink API [specifies](https://ci.apache.org/projects/flink/flink-docs-stable/monitoring/rest_api.html#jars-jarid-run)
program args should be passed as a comma separated list, which may not
be obvious to users. It's also annoying to pass large numbers of
arguments at once.